### PR TITLE
Add authentication fixes and responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,12 @@
-import { HashRouter, BrowserRouter ,  Routes,  Route,  Link  } from "react-router-dom";
-import GlobalStyle from "./styled/GlobalStyle"
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import GlobalStyle from "./styled/GlobalStyle";
 import Layout from "./components/Layout";
 import NotFiles from "./components/notfile/NotFiles";
 import Main from "./pages/main/Main";
 import Login from "./pages/login/Login";
 import Logout from "./pages/login/Logout";
 import Product from "./pages/product/Product";
-import Cart from "./pages/cart/cart";
+import Cart from "./pages/cart/Cart";
 import Notice from "./pages/notice/Notice";
 import Customer from "./pages/customer/Customer";
 import NoticeDetail from "./components/notice/NoticeDetail";
@@ -15,41 +15,41 @@ import CustomerDetail from "./components/customer/CustomerDetail";
 import CustomerAdd from "./components/customer/CustomerAdd";
 import CustomerEdit from "./components/customer/CustomerEdit";
 import LoginMain from "./pages/login/LoginMain";
+import Join from "./pages/login/Join";
  
 
 const App = () => {
   return (
     <>
-    <BrowserRouter>
-        <GlobalStyle /> 
+      <BrowserRouter>
+        <GlobalStyle />
         <Routes>
-          <Route path="/" element={<Layout/> }>
-          <Route index element={<Main />}/>
-          <Route path="/Main" element={<Main />}/>
-          <Route path="/logout" element={<Logout />}/>
-          <Route path="/about" element={<About />}/>
-          <Route path="/product" element={<Product />}/>
-          <Route path="/cart" element={<Cart />}/>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Main />} />
+            <Route path="main" element={<Main />} />
+            <Route path="logout" element={<Logout />} />
+            <Route path="about" element={<About />} />
+            <Route path="product" element={<Product />} />
+            <Route path="cart" element={<Cart />} />
 
-          <Route path="/notice">
-            <Route index element={<Notice/>}></Route>
-            <Route path=":noticeID" element={<NoticeDetail />}></Route>
+            <Route path="notice">
+              <Route index element={<Notice />} />
+              <Route path=":noticeID" element={<NoticeDetail />} />
+            </Route>
+
+            <Route path="customer">
+              <Route index element={<Customer />} />
+              <Route path=":customerID" element={<CustomerDetail />} />
+              <Route path="customeradd" element={<CustomerAdd />} />
+              <Route path="customeredit" element={<CustomerEdit />} />
+            </Route>
           </Route>
-          
-          <Route path="/customer">
-            
-          <Route index element={<Customer/>}></Route>
-            <Route path=":customerID" element={<CustomerDetail/>}></Route>
-            <Route path="customeradd" element={<CustomerAdd/>}></Route>
-            <Route path="customeredit" element={<CustomerEdit/>}></Route>
-          </Route>
-          
-          </Route>
-          <Route path="/login" element={<Login/>}/>
-          <Route path="/loginMain" element={<LoginMain/>}/>
-          <Route path="*" element={<NotFiles />}/>
+          <Route path="/login" element={<Login />} />
+          <Route path="/loginMain" element={<LoginMain />} />
+          <Route path="/join" element={<Join />} />
+          <Route path="*" element={<NotFiles />} />
         </Routes>
-     </BrowserRouter>
+      </BrowserRouter>
     </>
   );
 };

--- a/src/components/cart/CartStyle.js
+++ b/src/components/cart/CartStyle.js
@@ -1,73 +1,267 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
 export const CartListWrap = styled.div`
-.product-img{background:#E3F2FD}
-margin-top: 100px;
-margin-bottom:100px;
-h3{margin-top:10px}
-.cart-remove{
-button{width:130px; height:30px; font-size:14px; border:none; font-weight:600}
-button:first-child {margin-right:10px;}
-}
-.cart-del{margin-top:10px; font-size:40px;}
-.cart-con{display:flex; justify-content:space-between;}
-.title{font-size:30px; display:flex; justify-content:space-between}
-.cart-list{
-.cart-count{span{vertical-align:middle; font-size:20px;display:inline-block; margin:0px 10px 0px 10px;} margin:10px 0px 10px 0px; svg{vertical-align:middle; font-size:25px;}}
-display: flex;
-flex-wrap: wrap;
-width: 60%;
-border-top: 2px solid #E3F2FD;
-article {
-position: relative;
-.cart-select {
-position: absolute;
-left: 20px;
-top: 0px;
-input[type="checkbox"]{
-        display: none;
+  margin-top: 100px;
+  margin-bottom: 100px;
+  color: #e3f2fd;
+
+  h2 {
+    color: inherit;
+  }
+
+  .title {
+    font-size: 1.8rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .cart-remove {
+    display: flex;
+    gap: 12px;
+
+    button {
+      width: 130px;
+      height: 36px;
+      font-size: 0.9rem;
+      border: none;
+      font-weight: 600;
+      border-radius: 999px;
+      background: rgba(227, 242, 253, 0.15);
+      color: inherit;
+      transition: background 0.3s ease;
+
+      &:hover {
+        background: rgba(227, 242, 253, 0.25);
       }
-input[type="checkbox"] + label{
-        display: inline-block;
-        width: 20px;
-        height: 20px;
-        border:3px solid #E3F2FD;
-        position: relative;
+    }
+  }
+
+  .cart-con {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 40px;
+    margin-top: 40px;
+  }
+
+  .cart-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 28px;
+    flex: 1 1 60%;
+    border-top: 2px solid #e3f2fd;
+    padding-top: 20px;
+
+    article {
+      position: relative;
+      color: inherit;
+      text-align: center;
+      box-sizing: border-box;
+      padding: 24px 20px 28px;
+      border-radius: 16px;
+      border: 1px solid rgba(227, 242, 253, 0.2);
+      background: rgba(13, 27, 61, 0.35);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+
+      img {
+        width: 150px;
+        height: 100px;
+        object-fit: contain;
+        margin: 0 auto;
       }
-input:checked + label::after{
-        content:'✔';
-        font-size: 16px;
-        width: 20px;
-        height: 20px;
-        text-align: center;
+
+      .product-img {
+        background: #e3f2fd;
+        border-radius: 12px;
+        padding: 16px;
+      }
+
+      .cart-select {
         position: absolute;
-        left: 0;
-        top:0;
+        left: 16px;
+        top: 16px;
+
+        input[type="checkbox"] {
+          display: none;
+        }
+
+        input[type="checkbox"] + label {
+          display: inline-block;
+          width: 20px;
+          height: 20px;
+          border: 3px solid #e3f2fd;
+          position: relative;
+          border-radius: 4px;
+        }
+
+        input:checked + label::after {
+          content: "✔";
+          font-size: 16px;
+          width: 20px;
+          height: 20px;
+          text-align: center;
+          position: absolute;
+          left: 0;
+          top: 0;
+        }
       }
-}
-margin-top: 50px;
-color: #E3F2FD;
-text-align: center;
-box-sizing: border-box;
-padding:10%;
-width: 50%;
-border-right: 1px solid #E3F2FD;
-border-bottom: 1px solid #E3F2FD;
-img { width: 150px; height:100px;}
-}
-}
-h2 {color:white;}
-.cart-right {color: #E3F2FD; width:30%; border-top:2px solid #E3F2FD; line-height:2; padding-top:20px;
-button{width:100%; height: 50px; margin-top:20px; border:none; font-size:25px;font-weight:600}
-.cart-Total{
-    border-top: 4px solid #E3F2FD; margin-top: 20px;
-    border-bottom: 4px solid #E3F2FD;
-    padding: 10px;
-}
-.C-T{display:block; margin-left:auto; width:105px; margin-top:20px; font-size:20px}
-}
-`
+
+      .cart-count {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 12px;
+        span {
+          font-size: 1.1rem;
+        }
+        svg {
+          font-size: 1.5rem;
+        }
+      }
+    }
+  }
+
+  .cart-right {
+    color: inherit;
+    width: 320px;
+    border-top: 2px solid #e3f2fd;
+    line-height: 2;
+    padding-top: 20px;
+    background: rgba(13, 27, 61, 0.4);
+    border-radius: 20px;
+    padding: 28px;
+
+    p {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.95rem;
+      gap: 12px;
+    }
+
+    .cart-Total {
+      border-top: 4px solid #e3f2fd;
+      border-bottom: 4px solid #e3f2fd;
+      padding: 12px 0;
+      margin-top: 20px;
+      font-weight: 700;
+    }
+
+    .C-T {
+      display: block;
+      margin-left: auto;
+      width: auto;
+      margin-top: 12px;
+      font-size: 1.1rem;
+      text-align: right;
+    }
+
+    button {
+      width: 100%;
+      height: 50px;
+      margin-top: 20px;
+      border: none;
+      font-size: 1.1rem;
+      font-weight: 600;
+      border-radius: 999px;
+      background: #64ffda;
+      color: #003c3c;
+    }
+  }
+
+  @media (max-width: 1024px) {
+    .cart-con {
+      flex-direction: column;
+    }
+
+    .cart-right {
+      width: 100%;
+      max-width: 500px;
+    }
+  }
+
+  @media (max-width: 768px) {
+    margin-top: 80px;
+    margin-bottom: 80px;
+
+    .title {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .cart-remove {
+      width: 100%;
+      justify-content: flex-start;
+      flex-wrap: wrap;
+    }
+
+    .cart-con {
+      gap: 32px;
+    }
+
+    .cart-right {
+      width: 100%;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .cart-list {
+      grid-template-columns: 1fr;
+    }
+
+    .cart-remove {
+      flex-direction: column;
+      align-items: stretch;
+
+      button {
+        width: 100%;
+      }
+    }
+
+    .cart-right {
+      padding: 24px 20px;
+    }
+  }
+`;
+
 export const CartEmptyWrap = styled.div`
-.inner {position: relative; h2 { font-size: 60px; margin-top:200px; margin-bottom:200px; color:#E3F2FD}}
-a {width: 250px; background: #000; display: inline-block; height: 50px; line-height: 50px; color:#E3F2FD}
-`
+  .inner {
+    position: relative;
+
+    h2 {
+      font-size: clamp(2.2rem, 6vw, 3.5rem);
+      margin-top: 200px;
+      margin-bottom: 200px;
+      color: #e3f2fd;
+      text-align: center;
+    }
+  }
+
+  a {
+    width: 250px;
+    background: #000;
+    display: inline-block;
+    height: 50px;
+    line-height: 50px;
+    color: #e3f2fd;
+    text-align: center;
+    border-radius: 999px;
+  }
+
+  @media (max-width: 768px) {
+    .inner h2 {
+      margin-top: 120px;
+      margin-bottom: 120px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    a {
+      width: 100%;
+    }
+  }
+`;

--- a/src/components/customer/CustomerLIst.jsx
+++ b/src/components/customer/CustomerLIst.jsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { CustomerLIstWrap } from "./CustomerStyle";
 import CustomerItem from "./CustomerItem";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { addData } from "../../store/modules/paginationSlice";
 
 const CustomerLIst = () => {
@@ -21,18 +21,19 @@ const CustomerLIst = () => {
    
    return (
         <CustomerLIstWrap>
+        <div className="table-scroll">
         <table className="customerTable">
         <caption>게시판</caption>
         <colgroup>
             <col className="num" />
-            <col className="title" />               
-            <col className="name" />               
-            <col className="date" />               
+            <col className="title" />
+            <col className="name" />
+            <col className="date" />
         </colgroup>
         <thead>
             <tr>
                 <th>Number</th>
-                <th>Content</th>              
+                <th>Content</th>
                 <th>User</th>
                 <th>Date Created</th>
             </tr>
@@ -41,6 +42,7 @@ const CustomerLIst = () => {
              {currentPosts.map(item => <CustomerItem key={item.id} item={item}/>)}
        </tbody>
        </table>
+       </div>
             <p><button onClick={()=>navigate('customeradd')}>Create</button></p>
        </CustomerLIstWrap>
     );

--- a/src/components/customer/CustomerStyle.js
+++ b/src/components/customer/CustomerStyle.js
@@ -1,59 +1,235 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
-export const CustomerLIstWrap = styled.div` 
-    .customerTable { width: 100%; color:#E3F2FD;
-    caption { position:absolute; left:0; top:0; text-indent:-9999px}
-    .num { width: 10%; }
-    .title { width: auto;}
-    .date { width: 15%; }
-    th,  td{ height: 45px; vertical-align: middle; 
-        border: 1px solid #E3F2FD;}
-    th { border-bottom: none; font-weight: 700; background:#E3F2FD; color:#000035;}   
-    td{ text-align: center;
-        &:nth-child(2){ text-align: left; padding-left: 20px; } 
+export const CustomerLIstWrap = styled.div`
+  position: relative;
+
+  .table-scroll {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .customerTable {
+    width: 100%;
+    min-width: 640px;
+    color: #e3f2fd;
+    border-collapse: collapse;
+
+    caption {
+      position: absolute;
+      left: -9999px;
+      top: -9999px;
     }
-    a{color:#E3F2FD;}  
+
+    .num {
+      width: 10%;
     }
-    p  { text-align: right; margin-top: 50px;
-            button { width: 200px; height: 50px; background: none; color:#E3F2FD; border: 1px solid #E3F2FD; cursor: pointer;}
+
+    .title {
+      width: auto;
     }
-`
+
+    .date {
+      width: 15%;
+    }
+
+    th,
+    td {
+      height: 45px;
+      vertical-align: middle;
+      border: 1px solid rgba(227, 242, 253, 0.4);
+      padding: 0 16px;
+    }
+
+    th {
+      border-bottom: none;
+      font-weight: 700;
+      background: rgba(227, 242, 253, 0.9);
+      color: #000035;
+    }
+
+    td {
+      text-align: center;
+
+      &:nth-child(2) {
+        text-align: left;
+        padding-left: 20px;
+      }
+    }
+
+    a {
+      color: #e3f2fd;
+    }
+  }
+
+  p {
+    text-align: right;
+    margin-top: 40px;
+
+    button {
+      width: 200px;
+      height: 48px;
+      background: none;
+      color: #e3f2fd;
+      border: 1px solid #e3f2fd;
+      cursor: pointer;
+      border-radius: 12px;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .customerTable {
+      min-width: 540px;
+
+      th,
+      td {
+        font-size: 0.9rem;
+        padding: 0 12px;
+      }
+    }
+
+    p {
+      button {
+        width: 100%;
+      }
+    }
+  }
+`;
 
 export const CustomerAddWrap = styled.div`
-  .inner { padding:100px 0 }
-    h2 { font-size:30px; font-weight:700;margin-bottom:50px; color:#E3F2FD;}
-.customer-add {
-    p { margin-bottom: 15px;
-        input { width: 100%;height: 55px; padding: 20px; box-sizing: border-box;  }
-        textarea { width: 100%;height: 50px; box-sizing: border-box; height: 300px;  padding: 20px; }
-        button { width: 200px; height: 50px; background: none; color:#E3F2FD; cursor: pointer; border:1px solid  #E3F2FD; margin-right:5px }
-     }
- }
-   
-.customer-con { text-align: center; font-size: 20px; line-height: 1.7; }
-.customer-con + button { width: 250px; height: 45px; background: #000; color:#E3F2FD }
-`
-export const CustomerDetailWrap = styled.div`
-   color: #E3F2FD;
-  .inner { padding:100px 0 }
-    h2 { font-size:30px; font-weight:700; margin-bottom:50px }
+  .inner {
+    padding: 100px 0;
+  }
 
-    .con {  font-size: 20px; line-height: 1.7; border-top:1px solid  #E3F2FD;
-        border-bottom:1px solid #E3F2FD;
-             margin-bottom: 20px; padding: 20px 0; 
-       h3 {
-        font-size: 20px; font-weight: 500 ; padding-bottom: 15px;  border-bottom:1px solid #E3F2FD; margin-bottom: 15px 
-       }
-       .name {
-        font-size:18px; padding-bottom: 15px;  border-bottom:1px solid  #E3F2FD; margin-bottom: 15px 
-       }
-       .txt {
-        font-size:18px; margin-bottom: 15px;
-        height:300px; white-space: pre-line;
-       }
-       .date { font-size: 16px }
+  h2 {
+    font-size: 30px;
+    font-weight: 700;
+    margin-bottom: 50px;
+    color: #e3f2fd;
+  }
+
+  .customer-add {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    p {
+      margin-bottom: 15px;
+
+      input {
+        width: 100%;
+        height: 55px;
+        padding: 20px;
+        box-sizing: border-box;
+        border-radius: 12px;
+        border: none;
+      }
+
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        height: 300px;
+        padding: 20px;
+        border-radius: 12px;
+        border: none;
+      }
+
+      button {
+        width: 200px;
+        height: 50px;
+        background: none;
+        color: #e3f2fd;
+        cursor: pointer;
+        border: 1px solid #e3f2fd;
+        margin-right: 5px;
+        border-radius: 12px;
+      }
     }
-    button { width: 200px; height: 50px; background:none; color:#E3F2FD; cursor: pointer; border:none ;margin-right:5px; border:1px solid #E3F2FD; }
+  }
 
-`
+  .customer-con {
+    text-align: center;
+    font-size: 20px;
+    line-height: 1.7;
+  }
 
+  .customer-con + button {
+    width: 250px;
+    height: 45px;
+    background: #000;
+    color: #e3f2fd;
+  }
+
+  @media (max-width: 768px) {
+    .customer-add p button {
+      width: 100%;
+      margin-bottom: 8px;
+    }
+  }
+`;
+
+export const CustomerDetailWrap = styled.div`
+  color: #e3f2fd;
+
+  .inner {
+    padding: 100px 0;
+  }
+
+  h2 {
+    font-size: 30px;
+    font-weight: 700;
+    margin-bottom: 50px;
+  }
+
+  .con {
+    font-size: 20px;
+    line-height: 1.7;
+    border-top: 1px solid #e3f2fd;
+    border-bottom: 1px solid #e3f2fd;
+    margin-bottom: 20px;
+    padding: 20px 0;
+
+    h3 {
+      font-size: 20px;
+      font-weight: 500;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #e3f2fd;
+      margin-bottom: 15px;
+    }
+
+    .name {
+      font-size: 18px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #e3f2fd;
+      margin-bottom: 15px;
+    }
+
+    .txt {
+      font-size: 18px;
+      margin-bottom: 15px;
+      min-height: 200px;
+      white-space: pre-line;
+    }
+
+    .date {
+      font-size: 16px;
+    }
+  }
+
+  button {
+    width: 200px;
+    height: 50px;
+    background: none;
+    color: #e3f2fd;
+    cursor: pointer;
+    border: 1px solid #e3f2fd;
+    margin-right: 5px;
+    border-radius: 12px;
+  }
+
+  @media (max-width: 768px) {
+    button {
+      width: 100%;
+      margin: 5px 0;
+    }
+  }
+`;

--- a/src/components/notice/NoticeList.jsx
+++ b/src/components/notice/NoticeList.jsx
@@ -20,12 +20,13 @@ const NoticeList = () => {
 
     return (
         <NoticeListWrap>
+        <div className="table-scroll">
         <table className="noticeTable">
             <caption>게시판</caption>
             <colgroup>
                 <col className="num" />
-                <col className="title" />               
-                <col className="date" />               
+                <col className="title" />
+                <col className="date" />
             </colgroup>
             <thead>
                 <tr>
@@ -40,6 +41,7 @@ const NoticeList = () => {
                   }
            </tbody>
         </table>
+        </div>
         </NoticeListWrap>
     );
 };

--- a/src/components/notice/NoticeStyle.js
+++ b/src/components/notice/NoticeStyle.js
@@ -1,39 +1,135 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
-export const NoticeListWrap  = styled.div` 
+export const NoticeListWrap = styled.div`
+  position: relative;
 
-.noticeTable { width: 100%; color:#E3F2FD;
-    caption { position:absolute; left:0; top:0; text-indent:-9999px}
-    .num { width: 10%; }
-    .title { width: auto;}
-    .date { width: 15%; }
-    th,  td{ height: 45px; vertical-align: middle; 
-        border: 1px solid #E3F2FD;}
-    th { border-bottom: none; font-weight: 700; background:#E3F2FD; color:#000035;}   
-    td{ text-align: center;
-        &:nth-child(2){ text-align: left; padding-left: 20px; } 
+  .table-scroll {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .noticeTable {
+    width: 100%;
+    min-width: 600px;
+    color: #e3f2fd;
+    border-collapse: collapse;
+
+    caption {
+      position: absolute;
+      left: -9999px;
+      top: -9999px;
     }
-    a{color:#E3F2FD;}
-} 
 
-`
-
-export const NoticeDetailWrap = styled.div` 
-color: #E3F2FD;
-    .inner { padding:100px 0 }
-    h2 { font-size:30px; font-weight:700; margin-bottom:50px }
-
-    .con {  font-size: 20px; line-height: 1.7; border-top:1px solid #E3F2FD;
-        border-bottom:1px solid #E3F2FD;
-             margin-bottom: 20px; padding: 20px 0; 
-       h3 {
-        font-size: 20px; font-weight: 500 ; padding-bottom: 15px;  border-bottom:1px solid #dcdcdc ; margin-bottom: 15px 
-       }
-       .txt {
-        font-size:18px; margin-bottom: 15px;
-        height:300px; white-space: pre-line;
-       }
-       .date { font-size: 16px }
+    .num {
+      width: 10%;
     }
-    button { width: 200px; height: 50px; background:none; color:#E3F2FD; cursor: pointer; border:none ;margin-right:5px; border:1px solid #E3F2FD; }
-`
+
+    .title {
+      width: auto;
+    }
+
+    .date {
+      width: 20%;
+    }
+
+    th,
+    td {
+      height: 45px;
+      vertical-align: middle;
+      border: 1px solid rgba(227, 242, 253, 0.4);
+      padding: 0 16px;
+    }
+
+    th {
+      border-bottom: none;
+      font-weight: 700;
+      background: rgba(227, 242, 253, 0.9);
+      color: #000035;
+    }
+
+    td {
+      text-align: center;
+
+      &:nth-child(2) {
+        text-align: left;
+        padding-left: 20px;
+      }
+    }
+
+    a {
+      color: #e3f2fd;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .noticeTable {
+      min-width: 520px;
+
+      th,
+      td {
+        font-size: 0.9rem;
+        padding: 0 12px;
+      }
+    }
+  }
+`;
+
+export const NoticeDetailWrap = styled.div`
+  color: #e3f2fd;
+
+  .inner {
+    padding: 100px 0;
+  }
+
+  h2 {
+    font-size: 30px;
+    font-weight: 700;
+    margin-bottom: 50px;
+  }
+
+  .con {
+    font-size: 20px;
+    line-height: 1.7;
+    border-top: 1px solid #e3f2fd;
+    border-bottom: 1px solid #e3f2fd;
+    margin-bottom: 20px;
+    padding: 20px 0;
+
+    h3 {
+      font-size: 20px;
+      font-weight: 500;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #dcdcdc;
+      margin-bottom: 15px;
+    }
+
+    .txt {
+      font-size: 18px;
+      margin-bottom: 15px;
+      min-height: 200px;
+      white-space: pre-line;
+    }
+
+    .date {
+      font-size: 16px;
+    }
+  }
+
+  button {
+    width: 200px;
+    height: 50px;
+    background: none;
+    color: #e3f2fd;
+    cursor: pointer;
+    border: 1px solid #e3f2fd;
+    margin-right: 5px;
+    border-radius: 12px;
+  }
+
+  @media (max-width: 768px) {
+    button {
+      width: 100%;
+      margin: 6px 0;
+    }
+  }
+`;

--- a/src/components/pagination/paginationStyle.js
+++ b/src/components/pagination/paginationStyle.js
@@ -1,22 +1,49 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
-export const PaginationWrap  = styled.div` 
-    div{
- 
-        margin-top:30px;
-        text-align: center;
-        button {
-            border-radius: 5px;
-            width:30px; height:30px; border:1px soild #E3F2FD;
-            margin-right:5px; background:#fff;
-            &:first-child { border:none }
-            &:last-child { border:none }
-            &.on {
-                border-color:#E3F2FD;
-                background:#78c0f5;
-                color:black;
-                font-weight: 700;
-            }
-        }
+export const PaginationWrap = styled.div`
+  div {
+    margin-top: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+
+    button {
+      border-radius: 8px;
+      width: 36px;
+      height: 36px;
+      border: 1px solid rgba(227, 242, 253, 0.4);
+      background: rgba(227, 242, 253, 0.1);
+      color: #e3f2fd;
+      transition: background 0.3s ease, color 0.3s ease;
+
+      &:first-child,
+      &:last-child {
+        border: none;
+        background: transparent;
+        width: auto;
+        padding: 0 8px;
+        font-size: 1.2rem;
+      }
+
+      &.on {
+        border-color: #e3f2fd;
+        background: #78c0f5;
+        color: #001b44;
+        font-weight: 700;
+      }
     }
-`
+  }
+
+  @media (max-width: 480px) {
+    div {
+      gap: 6px;
+
+      button {
+        width: 32px;
+        height: 32px;
+      }
+    }
+  }
+`;

--- a/src/components/product/ProductSearch.jsx
+++ b/src/components/product/ProductSearch.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ProductSearchWrap } from './ProductStyle';
-import { useDispatch, useSelector } from 'react-redux';
-import { resetCart, searchCart, sortCart } from '../../store/modules/cartSlice';
+import { useSelector } from 'react-redux';
 
 const ProductSearch = ({NewProductData,SetNewProductData}) => {
     const [text, setText] = useState('')

--- a/src/components/product/ProductStyle.js
+++ b/src/components/product/ProductStyle.js
@@ -1,15 +1,96 @@
-import styled from 'styled-components'
-export const ProductSearchWrap = styled.div`
-margin-bottom:30px; position:relative;
- form {
-    display: flex;
-    justify-content: space-between;
-    p {        
-        input[type=text] { width:350px; box-sizing:border-box; height:45px; padding:10px; margin-right:10px; background:#E3F2FD; border:none; color: #000; border-radius:10px;}
-        button { width:100px; height:45px; vertical-align:top; background:none; border:1px solid #E3F2FD; color:#fff}
-        select { width:200px; height:45px; box-sizing:border-box; padding:10px; background-color:#E3F2FD; border:none; color: #000;}
-        span { margin-left:15px; cursor: pointer; color: #fff;}
-    }
- }
+import styled from "styled-components";
 
-`
+export const ProductSearchWrap = styled.div`
+  margin-bottom: 30px;
+  position: relative;
+
+  form {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 16px;
+
+    p {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+
+      input[type="text"] {
+        width: 320px;
+        box-sizing: border-box;
+        height: 45px;
+        padding: 10px 14px;
+        background: #e3f2fd;
+        border: none;
+        color: #000;
+        border-radius: 10px;
+      }
+
+      button {
+        width: 100px;
+        height: 45px;
+        background: none;
+        border: 1px solid #e3f2fd;
+        color: #fff;
+        border-radius: 10px;
+      }
+
+      select {
+        width: 200px;
+        height: 45px;
+        box-sizing: border-box;
+        padding: 10px;
+        background-color: #e3f2fd;
+        border: none;
+        color: #000;
+        border-radius: 10px;
+      }
+
+      span {
+        margin-left: 5px;
+        cursor: pointer;
+        color: #fff;
+        font-weight: 500;
+      }
+    }
+  }
+
+  @media (max-width: 900px) {
+    form {
+      gap: 12px;
+
+      p {
+        input[type="text"] {
+          width: 260px;
+        }
+        select {
+          width: 180px;
+        }
+      }
+    }
+  }
+
+  @media (max-width: 768px) {
+    form {
+      flex-direction: column;
+      align-items: stretch;
+
+      p {
+        width: 100%;
+        justify-content: flex-start;
+
+        input[type="text"],
+        select {
+          width: 100%;
+          max-width: none;
+        }
+
+        button {
+          width: auto;
+          padding: 0 24px;
+        }
+      }
+    }
+  }
+`;

--- a/src/footer/FooterStyle.js
+++ b/src/footer/FooterStyle.js
@@ -1,16 +1,100 @@
-import styled from 'styled-components'
- 
+import styled from "styled-components";
+
 export const FooterWrap = styled.footer`
-color: #E3F2FD;
-a{color: #E3F2FD;}
-    padding-bottom:50px;
-    background-color:#213067;
-    .inner {}
-    h2 { padding-top:80px; font-size:20px; color:#E3F2FD;}
-    .menu-social{width:200px; margin:auto; text-align:center; padding-top:50px;}
-    .brand-icon{display:flex; justify-content:space-between; svg{font-size:25px;}}
-    .nav-title{margin-bottom:20px;}
-    .navi{margin-bottom:20px;}
-    .copy{text-align: center; p{font-size:13px; margin-bottom:20px}}
-    .Terms{display:flex; margin-top:20px; margin-bottom:20px; li{font-size:13px;text-decoration: underline; text-underline-offset:5px;} justify-content:space-between}
-`
+  color: #e3f2fd;
+  background-color: #213067;
+  padding: 60px 0 40px;
+
+  a {
+    color: #e3f2fd;
+  }
+
+  .inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+  }
+
+  .menu-social {
+    text-align: center;
+  }
+
+  .brand-icon {
+    display: flex;
+    justify-content: center;
+    gap: 18px;
+
+    svg {
+      font-size: 26px;
+    }
+  }
+
+  .nav-title {
+    margin-bottom: 20px;
+    font-weight: 600;
+  }
+
+  .copy {
+    text-align: center;
+    max-width: 960px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    strong {
+      font-size: 0.95rem;
+    }
+
+    p {
+      font-size: 0.85rem;
+    }
+  }
+
+  .Terms {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 14px 24px;
+
+    li {
+      font-size: 0.85rem;
+      text-decoration: underline;
+      text-underline-offset: 5px;
+      white-space: nowrap;
+    }
+  }
+
+  @media (max-width: 768px) {
+    padding: 48px 0 32px;
+
+    .brand-icon {
+      gap: 12px;
+    }
+
+    .copy {
+      gap: 12px;
+      strong {
+        font-size: 0.9rem;
+      }
+    }
+
+    .Terms {
+      gap: 10px 16px;
+      li {
+        font-size: 0.8rem;
+      }
+    }
+  }
+
+  @media (max-width: 480px) {
+    .brand-icon {
+      flex-wrap: wrap;
+    }
+
+    .Terms {
+      flex-direction: column;
+      align-items: center;
+    }
+  }
+`;

--- a/src/header/HeaderStyle.js
+++ b/src/header/HeaderStyle.js
@@ -1,66 +1,202 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
 export const HeaderWrap = styled.header`
-background:#213067;
-    .inner { height:80px; }
-    h1 {
-        position:absolute; left:0; top:50%; transform: translateY(-50%); 
-        a {
-            img {
-                width:120px;
-            }
-        }      
+  background: #213067;
+  color: #e3f2fd;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  .inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 80px;
+    gap: 32px;
+  }
+  h1 {
+    margin: 0;
+    a {
+      display: inline-flex;
+      align-items: center;
+      img {
+        width: 120px;
+      }
     }
-    .login {
-      position: absolute; right: 150px; top: 10px;
-      color:blue;
-    }
-`
+  }
 
+  @media (max-width: 1024px) {
+    .inner {
+      height: 72px;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .inner {
+      flex-wrap: wrap;
+      gap: 12px;
+      padding: 12px 0;
+      height: auto;
+    }
+    h1 {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+  }
+`;
 
 export const NavWrap = styled.nav`
-   &.nav{ 
-    position: absolute; right:35%;  top:50% ; transform: translateY(-50%); 
-    ul{
-        display: flex;
-        .Cart{position:absolute; right: -60%;svg{font-size:30px; position:absolute; left:-30px; top: -10px;}}
-        .login {position:absolute; right:-50%; top:0px; svg{font-size:30px; position:absolute; left:-30px; top: -10px;}}
-        li {
-            margin-left:100px; position:relative ;
-            a {
-                color: #E3F2FD;
-                font-size:15px; font-weight: 500;
-                transition:0.3s;
-                &:hover {
-                    color:#64B5F6;
-                }
-            }
-            &:last-child span{ 
-                font-size:16px;
-                border-radius:50% ;               
-                display: block;
-                position:absolute ;
-                right:-20px; top:-5px; 
-                width:20px; height:20px; 
-                text-align:center; line-height:20px ;
-            }
-        }
+  &.nav {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    position: relative;
+    color: #e3f2fd;
+
+    .menu-toggle {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      width: 42px;
+      height: 42px;
+      border-radius: 50%;
+      border: 1px solid rgba(227, 242, 253, 0.2);
+      background: transparent;
+      color: inherit;
+      font-size: 1.6rem;
+      cursor: pointer;
+      transition: background 0.3s ease;
     }
-}
-`
 
-
-export const TopMenu  = styled.ul`
-    &.top-menu {
-        position: absolute; right:0;  top:10px;
-        display: flex;
-        li {
-            margin-left:25px;
-            a {
-                font-size:15px;                
-            }
-        }
+    ul {
+      display: flex;
+      align-items: center;
+      gap: 32px;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      z-index: 10;
     }
-    
 
-`
+    li {
+      position: relative;
+      font-size: 0.95rem;
+      font-weight: 500;
+      a {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: inherit;
+        transition: color 0.3s ease;
+
+        &.active,
+        &:hover {
+          color: #90caf9;
+        }
+      }
+
+      &.welcome {
+        font-size: 0.85rem;
+        color: #bbdefb;
+      }
+
+      &.cart {
+        a {
+          position: relative;
+        }
+        .count {
+          position: absolute;
+          top: -6px;
+          right: -12px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 22px;
+          height: 22px;
+          font-size: 0.75rem;
+          border-radius: 999px;
+          background: #90caf9;
+          color: #0d1b3d;
+          font-weight: 700;
+        }
+      }
+    }
+
+    @media (max-width: 1024px) {
+      ul {
+        gap: 20px;
+      }
+    }
+
+    @media (max-width: 768px) {
+      width: 100%;
+      justify-content: flex-end;
+
+      .menu-toggle {
+        display: inline-flex;
+      }
+
+      ul {
+        position: absolute;
+        right: 0;
+        top: calc(100% + 12px);
+        flex-direction: column;
+        align-items: flex-start;
+        background: rgba(13, 27, 61, 0.95);
+        border-radius: 16px;
+        padding: 20px;
+        gap: 16px;
+        width: min(260px, 100vw - 32px);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+        opacity: 0;
+        pointer-events: none;
+        transform: translateY(-10px);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+      }
+
+      &.open ul {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translateY(0);
+      }
+
+      li {
+        width: 100%;
+        a {
+          width: 100%;
+        }
+        &.cart {
+          width: auto;
+        }
+      }
+    }
+
+    @media (max-width: 480px) {
+      ul {
+        padding: 16px;
+        gap: 12px;
+      }
+      .menu-toggle {
+        width: 36px;
+        height: 36px;
+        font-size: 1.4rem;
+      }
+    }
+  }
+`;
+
+export const TopMenu = styled.ul`
+  &.top-menu {
+    position: absolute;
+    right: 0;
+    top: 10px;
+    display: flex;
+    li {
+      margin-left: 25px;
+      a {
+        font-size: 15px;
+      }
+    }
+  }
+`;

--- a/src/header/NavBar.jsx
+++ b/src/header/NavBar.jsx
@@ -1,34 +1,74 @@
-import { Link } from "react-router-dom"; 
-import { NavWrap, TopMenu } from "./HeaderStyle";
+import { useState } from "react";
+import { Link, NavLink } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { HiMiniShoppingCart } from "react-icons/hi2";
-import { BiSolidLogIn } from "react-icons/bi";
-
-
+import { HiBars3, HiMiniShoppingCart } from "react-icons/hi2";
+import { BiSolidLogIn, BiLogOut } from "react-icons/bi";
+import { NavWrap } from "./HeaderStyle";
 
 const NavBar = () => {
-    const {carts} = useSelector(state => state.cart)
-    return (
-        <>
-        <NavWrap className="nav">
-            <ul>             
-                <li><Link to={"/about"}>About</Link></li>
-                <li><Link to={"/product"}>Product</Link></li>
-                <li><Link to={"/notice"}>Notice</Link></li>
-                <li><Link to={"/customer"}>Customer</Link></li>
-                <li className="login"><Link to="/loginMain"><BiSolidLogIn />Login</Link></li>
-                <li className="Cart"><Link to="/cart"><HiMiniShoppingCart /><span>{carts.length}</span></Link></li>                        
-            </ul>
-        </NavWrap>
+  const { carts } = useSelector((state) => state.cart);
+  const { authed, user } = useSelector((state) => state.auth);
+  const [open, setOpen] = useState(false);
 
-       {/*  <TopMenu className="top-menu">
-             <li><Link to={"/join"}>회원가입</Link></li>
-                
-                    <li><Link to={"/logout"}>로그아웃</Link></li>
-                    <li><Link to={"/login"}>로그인</Link></li>
-       </TopMenu>       */}
-        </>
-    );
+  const toggleMenu = () => {
+    setOpen((prev) => !prev);
+  };
+
+  const closeMenu = () => {
+    setOpen(false);
+  };
+
+  const navItems = [
+    { to: "/about", label: "About" },
+    { to: "/product", label: "Product" },
+    { to: "/notice", label: "Notice" },
+    { to: "/customer", label: "Customer" },
+  ];
+
+  return (
+    <NavWrap className={`nav ${open ? "open" : ""}`}>
+      <button
+        type="button"
+        className="menu-toggle"
+        onClick={toggleMenu}
+        aria-label="메뉴 토글"
+        aria-expanded={open}
+        aria-controls="primary-navigation"
+      >
+        <HiBars3 />
+      </button>
+      <ul id="primary-navigation">
+        {navItems.map(({ to, label }) => (
+          <li key={to}>
+            <NavLink to={to} onClick={closeMenu}>
+              {label}
+            </NavLink>
+          </li>
+        ))}
+        {authed && (
+          <li className="welcome">
+            <span>{user?.username ?? ""} 님</span>
+          </li>
+        )}
+        <li className="login">
+          <Link to={authed ? "/logout" : "/loginMain"} onClick={closeMenu}>
+            {authed ? <BiLogOut /> : <BiSolidLogIn />}
+            {authed ? "Logout" : "Login"}
+          </Link>
+        </li>
+        <li className="cart">
+          <Link to="/cart" onClick={closeMenu}>
+            <span className="sr-only">Cart</span>
+            <HiMiniShoppingCart />
+            <span className="count" aria-live="polite">
+              {carts.length}
+            </span>
+          </Link>
+        </li>
+      </ul>
+    </NavWrap>
+  );
 };
 
 export default NavBar;
+

--- a/src/pages/about/About.jsx
+++ b/src/pages/about/About.jsx
@@ -41,7 +41,13 @@ const About = () => {
                 </div>
                 <div className="box-right">
                     <div className="video-box">
-                    <video src="./images/Star Wars Intro.mp4" autoPlay={true} loop={true} muted={true}></video>
+                    <video
+                      src="./images/Star Wars Intro.mp4"
+                      autoPlay
+                      loop
+                      muted
+                      playsInline
+                    ></video>
                     </div>
                     <div className="title-content">
                     <p className="title">Contact</p>

--- a/src/pages/about/AboutStyle.js
+++ b/src/pages/about/AboutStyle.js
@@ -1,23 +1,129 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
 export const AboutWrap = styled.div`
-.inner{margin-top:100px;margin-bottom:100px;}
-color:#E3F2FD;
-.nav {display:flex; li{margin-right:10px; cursor: pointer; font-size:25px}margin-bottom:30px;}
+  color: #e3f2fd;
 
-.content{display:flex; justify-content:space-between;
-.title-content{margin-top:15px;
-.title {margin-bottom:10px;color:#80CBC4;}
-.text-content {
-line-height: 1.6;
-ul{display:flex; li{border:1px solid #E3F2FD;margin-right: 10px; padding:10px; text-align:center; span{font-size:15px; margin-top:10px; display:inline-block;} svg{vertical-align:middle; font-size:80px;}}
-}
-}
-}  
-.box-left{width:50%;}
-.box-right{width:40%;}
-.video-box{
-    video{width:100%;}
-}
-}
-`
+  .inner {
+    margin-top: 100px;
+    margin-bottom: 100px;
+  }
+
+  .nav {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 30px;
+
+    li {
+      cursor: pointer;
+      font-size: 1.4rem;
+      font-weight: 600;
+    }
+  }
+
+  .content {
+    display: flex;
+    justify-content: space-between;
+    gap: 40px;
+
+    .box-left {
+      width: 50%;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .box-right {
+      width: 40%;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .title-content {
+      margin-top: 15px;
+
+      .title {
+        margin-bottom: 10px;
+        color: #80cbc4;
+        font-weight: 600;
+        font-size: 1.1rem;
+      }
+
+      .text-content {
+        line-height: 1.6;
+
+        ul {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+
+          li {
+            border: 1px solid #e3f2fd;
+            padding: 12px 16px;
+            text-align: center;
+            border-radius: 16px;
+            min-width: 120px;
+
+            span {
+              font-size: 0.95rem;
+              margin-top: 10px;
+              display: inline-block;
+            }
+
+            svg {
+              vertical-align: middle;
+              font-size: 42px;
+            }
+          }
+        }
+      }
+    }
+
+    .video-box {
+      border-radius: 24px;
+      overflow: hidden;
+
+      video {
+        width: 100%;
+        display: block;
+      }
+    }
+  }
+
+  @media (max-width: 1024px) {
+    .content {
+      gap: 32px;
+
+      .box-left,
+      .box-right {
+        width: 100%;
+      }
+    }
+  }
+
+  @media (max-width: 768px) {
+    .inner {
+      margin-top: 80px;
+      margin-bottom: 80px;
+    }
+
+    .nav {
+      flex-wrap: wrap;
+      font-size: 1.2rem;
+    }
+
+    .content {
+      flex-direction: column;
+
+      .title-content .text-content ul {
+        justify-content: flex-start;
+      }
+    }
+  }
+
+  @media (max-width: 480px) {
+    .title-content .text-content ul li {
+      min-width: 100px;
+    }
+  }
+`;

--- a/src/pages/customer/Customer.jsx
+++ b/src/pages/customer/Customer.jsx
@@ -1,6 +1,6 @@
  
 import CustomerLIst from '../../components/customer/CustomerLIst';
-import Pagination from '../../components/pagination/pagination';
+import Pagination from '../../components/pagination/Pagination';
 import { CustomerWrap } from './CustomerStyle';
  
  

--- a/src/pages/login/Join.jsx
+++ b/src/pages/login/Join.jsx
@@ -1,38 +1,130 @@
-import { JoinWrap  } from "./LoginStyle";
-import Spinner from "../../components/Spinner";
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useNavigate } from "react-router-dom";
+import { JoinWrap } from "./LoginStyle";
+import { signup } from "../../store/modules/authSlice";
 
 const Join = () => {
-    return (
-        <>  
-            
-            <JoinWrap>
-                <div className="inner">
-                <h2> 회원가입 </h2>
-                <form >
-                    <p>
-                        <label> 이름 </label>  
-                        <input type="text"  placeholder="홍길동" />
-                    </p>                
-                    <p>
-                        <label> 전화번호 </label>  
-                        <input type="tel" name="tel" placeholder="010-0000-0000" />
-                    </p>                
-                    <p>
-                        <label>이메일 </label>  
-                        <input type="email" name="email"   placeholder="abc@naver.com" />
-                    </p>                
-                    <p>
-                        <label>비밀번호 </label>  
-                        <input type="password" name="password"   placeholder="a1234" />
-                    </p>
-                    <p><button type="submit">회원가입</button>
-                       <button >취소</button></p>
-                </form>
-                </div>
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { dataList } = useSelector((state) => state.auth);
+  const [form, setForm] = useState({
+    username: "",
+    tel: "",
+    email: "",
+    password: "",
+  });
+  const [error, setError] = useState("");
 
-            </JoinWrap>
-        </>
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+    if (error) {
+      setError("");
+    }
+  };
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const trimmed = Object.fromEntries(
+      Object.entries(form).map(([key, value]) => [key, value.trim()])
     );
+
+    const normalized = {
+      ...trimmed,
+      email: trimmed.email.toLowerCase(),
+      tel: trimmed.tel.replace(/[^0-9-]/g, ""),
+    };
+
+    if (Object.values(normalized).some((value) => !value)) {
+      setError("모든 입력 항목을 빠짐없이 입력해 주세요.");
+      return;
+    }
+
+    if (dataList.some((user) => user.email === normalized.email)) {
+      setError("이미 가입된 이메일입니다. 다른 이메일을 사용해 주세요.");
+      return;
+    }
+
+    dispatch(signup(normalized));
+    navigate("/login", { replace: true });
+  };
+
+  const onCancel = () => {
+    navigate(-1);
+  };
+
+  return (
+    <JoinWrap>
+      <div className="inner">
+        <h2>회원가입</h2>
+        <form onSubmit={onSubmit}>
+          <p>
+            <label htmlFor="username">이름</label>
+            <input
+              id="username"
+              type="text"
+              name="username"
+              placeholder="홍길동"
+              value={form.username}
+              onChange={onChange}
+              required
+            />
+          </p>
+          <p>
+            <label htmlFor="tel">전화번호</label>
+            <input
+              id="tel"
+              type="tel"
+              name="tel"
+              placeholder="010-0000-0000"
+              value={form.tel}
+              onChange={onChange}
+              inputMode="tel"
+              pattern="^0\d{1,2}-?\d{3,4}-?\d{4}$"
+              required
+            />
+          </p>
+          <p>
+            <label htmlFor="email">이메일</label>
+            <input
+              id="email"
+              type="email"
+              name="email"
+              placeholder="abc@example.com"
+              value={form.email}
+              onChange={onChange}
+              required
+            />
+          </p>
+          <p>
+            <label htmlFor="password">비밀번호</label>
+            <input
+              id="password"
+              type="password"
+              name="password"
+              placeholder="영문과 숫자 조합 6자 이상"
+              minLength={6}
+              value={form.password}
+              onChange={onChange}
+              required
+            />
+          </p>
+          {error && <div className="error" role="alert">{error}</div>}
+          <p>
+            <button type="submit">회원가입</button>
+            <button type="button" onClick={onCancel} className="ghost">
+              취소
+            </button>
+          </p>
+        </form>
+        <div className="login-bottom">
+          <span>이미 가입하셨나요?</span>
+          <Link to="/login">로그인 하러가기</Link>
+        </div>
+      </div>
+    </JoinWrap>
+  );
 };
 
 export default Join;

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,55 +1,86 @@
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { Link, useNavigate } from "react-router-dom";
-import { LoginWrap  } from "./LoginStyle";
-import { useRef, useState } from "react";
-import { useDispatch } from "react-redux";
 import { login } from "../../store/modules/authSlice";
+import { LoginWrap } from "./LoginStyle";
 
 
  
  
 const Login = () => {
     const [user, setUser] = useState({
-        email:'', password:''
-    })
-    const emailRef = useRef()
-    const {email,password} = user;
-    
-    const navigate = useNavigate()
-    const dispatch = useDispatch()
+        email: "",
+        password: "",
+    });
+    const { email, password } = user;
+
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const { authed } = useSelector((state) => state.auth);
+
+    useEffect(() => {
+        if (authed) {
+            navigate("/");
+        }
+    }, [authed, navigate]);
 
     const onSubmit = (e) => {
-        e.preventDefault()
-        if(!email || !password) return
-            dispatch(login(user))
-            navigate('/main')
+        e.preventDefault();
+        if (!email || !password) return;
+
+        dispatch(login(user));
         setUser({
-            email:'',
-            password:''
-        })
-    }
+            email: "",
+            password: "",
+        });
+    };
 
     const onInput = (e) => {
-        const {name,value} = e.target 
-        setUser({...user,[name]:value})
-    }
+        const { name, value } = e.target;
+        setUser({ ...user, [name]: value });
+    };
 
     return (
         <LoginWrap>
             <div className="inner">
             <div className="Login-form">
-            <div><Link to={'/main'}><img src="./images/sw_logo.jpg" alt="" /></Link></div>
+            <div>
+              <Link to={"/"}>
+                <img src="./images/sw_logo.jpg" alt="Star Shop" />
+              </Link>
+            </div>
             <h2>Login</h2>
-            <form onClick={onSubmit}>
+            <form onSubmit={onSubmit}>
                 <p>
-                    <label>이메일</label>  
-                    <input type="email"   placeholder="" name='email' value={email} onChange={onInput}/>
-                </p>                
-                <p>
-                    <label>비밀번호</label>  
-                    <input type="password"   placeholder="" name='password' value={password} onChange={onInput}/>
+                    <label>이메일</label>
+                    <input
+                      type="email"
+                      placeholder="name@example.com"
+                      name="email"
+                      value={email}
+                      onChange={onInput}
+                      required
+                    />
                 </p>
-                <p><button type="submit">Login</button></p>
+                <p>
+                    <label>비밀번호</label>
+                    <input
+                      type="password"
+                      placeholder="영문+숫자 6자 이상"
+                      name="password"
+                      value={password}
+                      onChange={onInput}
+                      required
+                    />
+                </p>
+                <p>
+                  <button type="submit">Login</button>
+                </p>
             </form>
+            <div className="login-bottom">
+              <span>아직 계정이 없으신가요?</span>
+              <Link to="/join">회원가입</Link>
+            </div>
             </div>
             </div>
         </LoginWrap>

--- a/src/pages/login/LoginMain.jsx
+++ b/src/pages/login/LoginMain.jsx
@@ -1,23 +1,45 @@
-import React from 'react';
-import { LoginMainWrap } from './LoginStyle';
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
+import { LoginMainWrap } from "./LoginStyle";
 
 const LoginMain = () => {
-    return (
-        <LoginMainWrap>
-            <div className='Login-left'>
-                     <h2><Link to={'/main'}><img src="./images/sw_logo.jpg" alt="" /></Link></h2>
-                    <video width={'100%'} src="./images/login_page_vid.mp4" autoPlay={true} loop={true}>
-                    </video>
-            </div>
-            <div className='Login-right'>
-                <div className='Login-box'>
-                    <h2>Get started</h2>
-                    <div className='button-box'><Link to={'/login'}><button>Login</button></Link><Link to={'/join'}><button>Sign up</button></Link></div>
-                </div>
-            </div>
-        </LoginMainWrap>
-    );
+  return (
+    <LoginMainWrap>
+      <div className="Login-left">
+        <h2>
+          <Link to="/">
+            <img src="./images/sw_logo.jpg" alt="Star Shop" />
+          </Link>
+        </h2>
+        <video
+          width="100%"
+          src="./images/login_page_vid.mp4"
+          autoPlay
+          loop
+          muted
+          playsInline
+        />
+      </div>
+      <div className="Login-right">
+        <div className="Login-box">
+          <h2>Get started</h2>
+          <p className="description">
+            로그인하면 장바구니와 고객센터를 포함한 모든 서비스를 이용할 수
+            있습니다.
+          </p>
+          <div className="button-box">
+            <Link to="/login">
+              <button type="button">Login</button>
+            </Link>
+            <Link to="/join">
+              <button type="button" className="secondary">
+                Sign up
+              </button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </LoginMainWrap>
+  );
 };
 
 export default LoginMain;

--- a/src/pages/login/LoginStyle.js
+++ b/src/pages/login/LoginStyle.js
@@ -1,88 +1,406 @@
-import styled from 'styled-components'
-
+import styled from "styled-components";
 
 export const LoginWrap = styled.div`
- .inner {
-position: relative;
-.Login-form{text-align:center; position:absolute; left:50%; top:50%; transform:translate(-50%,50%)}
-h2 { font-size:20px; font-weight:700; margin-bottom:50px; color:#E3F2FD; text-align:right;}
-img{width:250px;}
-p {
+  .inner {
     position: relative;
-    margin-bottom: 30px;
-    label {color: #E3F2FD;position:absolute; left: 0px; top:-20px;}
-    input[type=email] , input[type=password]{
-        margin-top:5px;
-        width:250px; box-sizing: border-box;
-        height:50px; padding:0 10px; 
-    }
-    
-    &:last-child {
-        margin-top:50px; text-align: center;
-        button {
-        width:150px; height:60px; background: none; border:1px solid #E3F2FD; color: #E3F2FD;
-        cursor: pointer;
-    }
-    }
- }   
+    min-height: 80vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 
-}
-`
+  .Login-form {
+    width: min(420px, 100%);
+    background: rgba(13, 27, 61, 0.55);
+    border-radius: 24px;
+    padding: 48px 40px 40px;
+    text-align: center;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  }
+
+  h2 {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 36px;
+    color: #e3f2fd;
+  }
+
+  img {
+    width: 180px;
+    margin-bottom: 16px;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  p {
+    position: relative;
+    text-align: left;
+
+    label {
+      display: block;
+      margin-bottom: 8px;
+      color: #e3f2fd;
+      font-weight: 600;
+    }
+
+    input[type="email"],
+    input[type="password"] {
+      width: 100%;
+      box-sizing: border-box;
+      height: 52px;
+      padding: 0 16px;
+      border-radius: 12px;
+      border: none;
+      background: rgba(227, 242, 253, 0.9);
+      color: #0d1b3d;
+      font-size: 0.95rem;
+    }
+
+    &:last-of-type {
+      margin-top: 12px;
+      text-align: center;
+
+      button {
+        width: 100%;
+        height: 54px;
+        background: #546e7a;
+        border: none;
+        border-radius: 12px;
+        color: #fff;
+        font-size: 1rem;
+      }
+    }
+  }
+
+  .login-bottom {
+    margin-top: 28px;
+    font-size: 0.95rem;
+    color: #bbdefb;
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+
+    a {
+      color: #64b5f6;
+      font-weight: 600;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .Login-form {
+      padding: 36px 24px 32px;
+    }
+
+    img {
+      width: 150px;
+    }
+  }
+`;
+
 export const LoginMainWrap = styled.div`
-display: flex; justify-content: space-between;
-.Login-left{width:40%; position:relative; background:#000; video{position:absolute; left:0; top:50%; transform:translateY(-50%)}
-h2{img{
-    width: 200px; opacity: 0.2; margin-top: 30px; margin-left: 30px; cursor: pointer;
-}}
-}
-.Login-right{width:60%;height:100vh; position: relative; text-align: center;
-.Login-box{position:absolute; left:50%;top:50%; transform:translate(-50%,-50%);
-.button-box{display:flex;}    
-button {width:250px; height:50px; background:none; border:1px solid #E3F2FD; color:#E3F2FD}
-button:first-child {margin-right:10px;}
-h2 {color: #E3F2FD; font-size:40px; margin-bottom:50px}
-}
-}
-`
+  min-height: 100vh;
+  display: flex;
+  flex-wrap: wrap;
+  background: radial-gradient(circle at top, rgba(55, 71, 133, 0.4), transparent);
 
+  .Login-left,
+  .Login-right {
+    flex: 1 1 50%;
+    position: relative;
+  }
 
+  .Login-left {
+    background: #000;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+
+    h2 {
+      position: absolute;
+      top: 24px;
+      left: 24px;
+      z-index: 2;
+      img {
+        width: 200px;
+        opacity: 0.5;
+        transition: opacity 0.3s ease;
+        cursor: pointer;
+      }
+    }
+
+    video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      filter: brightness(0.85);
+    }
+  }
+
+  .Login-right {
+    min-height: 100vh;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 60px 20px;
+
+    .Login-box {
+      max-width: 420px;
+      width: 100%;
+      background: rgba(13, 27, 61, 0.7);
+      padding: 48px 40px;
+      border-radius: 28px;
+      box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+
+      h2 {
+        color: #e3f2fd;
+        font-size: 2.2rem;
+        margin-bottom: 20px;
+      }
+
+      .description {
+        margin-bottom: 36px;
+        color: #bbdefb;
+        font-size: 1rem;
+        line-height: 1.7;
+      }
+
+      .button-box {
+        display: flex;
+        justify-content: center;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      button {
+        width: 180px;
+        height: 50px;
+        background: none;
+        border: 1px solid #e3f2fd;
+        color: #e3f2fd;
+        border-radius: 14px;
+        font-size: 1rem;
+        transition: background 0.3s ease, color 0.3s ease;
+
+        &:hover {
+          background: #e3f2fd;
+          color: #0d1b3d;
+        }
+
+        &.secondary {
+          background: rgba(227, 242, 253, 0.2);
+        }
+      }
+    }
+  }
+
+  @media (max-width: 1024px) {
+    .Login-right {
+      min-height: auto;
+    }
+  }
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+
+    .Login-left,
+    .Login-right {
+      flex: 1 1 auto;
+      width: 100%;
+    }
+
+    .Login-left {
+      min-height: 360px;
+      h2 {
+        img {
+          opacity: 0.7;
+        }
+      }
+    }
+
+    .Login-right {
+      padding: 60px 16px 80px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .Login-right {
+      padding: 48px 16px 72px;
+
+      .Login-box {
+        padding: 36px 24px;
+
+        h2 {
+          font-size: 1.75rem;
+        }
+
+        .description {
+          font-size: 0.95rem;
+        }
+
+        button {
+          width: 100%;
+        }
+      }
+    }
+  }
+`;
 
 export const LogoutWrap = styled.div`
-     .inner { padding:100px 0 ; display:flex ; flex-direction:column; justify-content: center; align-items:center; height:600px; }
-     h2 { font-size:30px; font-weight:700; margin-bottom:50px  }
-     h3 { margin-bottom:30px; font-size:25px; font-weight:700;
-        span {
-            color:tomato
-        }
-     }
-     p {
-        margin-top:50px; text-align: center;
-        button {
-          width:250px; height:60px; background: #546E7A; color:#fff; border:none; cursor: pointer;
-        }
+  .inner {
+    padding: 100px 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 60vh;
+    text-align: center;
+  }
+
+  h2 {
+    font-size: 1.9rem;
+    font-weight: 700;
+    margin-bottom: 30px;
+  }
+
+  h3 {
+    margin-bottom: 24px;
+    font-size: 1.3rem;
+    font-weight: 700;
+
+    span {
+      color: tomato;
     }
-` 
+  }
+
+  p {
+    margin-top: 20px;
+
+    button {
+      width: 240px;
+      height: 54px;
+      background: #546e7a;
+      color: #fff;
+      border: none;
+      border-radius: 14px;
+      font-size: 1rem;
+    }
+  }
+`;
 
 export const JoinWrap = styled.div`
- .inner { padding:100px 0 ; display:flex ; flex-direction:column; justify-content: center; align-items:center; height:750px; }
- h2 { font-size:30px; font-weight:700; margin-bottom:50px  }
- p {
-    margin-bottom: 15px;
+  .inner {
+    padding: 100px 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 80vh;
+  }
+
+  h2 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 40px;
+  }
+
+  form {
+    width: min(460px, 100%);
+    background: rgba(13, 27, 61, 0.55);
+    border-radius: 24px;
+    padding: 40px 36px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  }
+
+  p {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
     label {
-        display: block; width:110px;
+      color: #e3f2fd;
+      font-weight: 600;
     }
-    input[type=email] , input[type=password], input[type=tel], input[type=text]{
-        margin-top:5px;
-        width:450px; box-sizing: border-box;
-        height:55px; padding:0 10px;
+
+    input[type="email"],
+    input[type="password"],
+    input[type="tel"],
+    input[type="text"] {
+      width: 100%;
+      box-sizing: border-box;
+      height: 52px;
+      padding: 0 16px;
+      border-radius: 12px;
+      border: none;
+      background: rgba(227, 242, 253, 0.9);
+      color: #0d1b3d;
+      font-size: 0.95rem;
     }
-    
-    &:last-child {
-        margin-top:50px; text-align: center;
-        button {
-            width:200px; height:60px; background: #546E7A; color:#fff; border:none;
-            cursor: pointer;margin-left:5px; 
+  }
+
+  .error {
+    padding: 12px 16px;
+    border-radius: 12px;
+    background: rgba(244, 67, 54, 0.2);
+    color: #ff8a65;
+    font-size: 0.9rem;
+  }
+
+  button {
+    width: 200px;
+    height: 52px;
+    background: #546e7a;
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .ghost {
+    background: transparent;
+    border: 1px solid #e3f2fd;
+  }
+
+  form > p:last-child {
+    margin-top: 12px;
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .login-bottom {
+    margin-top: 28px;
+    font-size: 0.95rem;
+    color: #bbdefb;
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+
+    a {
+      color: #64b5f6;
+      font-weight: 600;
     }
+  }
+
+  @media (max-width: 480px) {
+    form {
+      padding: 32px 24px;
     }
- }   
-`
+
+    button {
+      width: 100%;
+    }
+  }
+`;

--- a/src/pages/login/Logout.jsx
+++ b/src/pages/login/Logout.jsx
@@ -1,22 +1,38 @@
- 
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import { logout } from "../../store/modules/authSlice";
 import { LogoutWrap } from "./LoginStyle";
- 
+
 
 const Logout = () => {
-    
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const { authed, user } = useSelector((state) => state.auth);
+
+    useEffect(() => {
+        if (!authed) {
+            navigate("/loginMain");
+        }
+    }, [authed, navigate]);
+
+    const onLogout = () => {
+        dispatch(logout());
+    };
 
     return (
         <LogoutWrap>
-             <div className="inner">
-                
-                    
-                    <>
-                    <h2>방문해 주셔서 감사합니다.<br/> 다시 방문해주세요</h2>
-                    <h3><span> 님 이용해주셔서 감사합니다 </span> </h3>
-                     
-                    <p> <button  >로그아웃</button> </p>
-                </>  
-                    
+            <div className="inner">
+                <h2>
+                    방문해 주셔서 감사합니다.
+                    <br /> 다시 방문해주세요
+                </h2>
+                <h3>
+                    <span>{user?.username ?? ""} 님</span> 이용해주셔서 감사합니다
+                </h3>
+                <p>
+                    <button onClick={onLogout}>로그아웃</button>
+                </p>
             </div>
         </LogoutWrap>
     );

--- a/src/pages/main/Banner.jsx
+++ b/src/pages/main/Banner.jsx
@@ -8,7 +8,13 @@ const Banner = () => {
         <div className="inner">
         <span className="Main-Text"><Link to={'/product'}>Click here to shop if you have items you want to purchase!</Link></span>
         <div className="video-box">
-        <video src="./images/visual_vid.mp4" autoPlay={true} loop={true}>
+        <video
+          src="./images/visual_vid.mp4"
+          autoPlay
+          loop
+          muted
+          playsInline
+        >
         </video>
         <div className="buy-now"><Link to={'/product'}>Buy Now</Link></div>
         </div>

--- a/src/pages/main/ContentStyle.js
+++ b/src/pages/main/ContentStyle.js
@@ -1,38 +1,171 @@
 import styled from "styled-components";
 
 export const ContentStyle = styled.section`
-width: 100%;
-/* opacity: 0.8; */
-display: flex;
-justify-content: space-between;
-.img-box {width:50%;img{width:100%;}}
-.text-box {position:relative; width:50%;  color: white; h2{font-size:18px;}
-text-align: center;
-span{display:block; font-size:14px;}
-.inner-box{
-width: 450px;
-.go-shop{margin-right:auto; margin-left:auto; margin-top:30px}
-position:absolute; left:50%; top:50%; 
-transform:translate(-50%,-50%)}
-}
-`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 60px;
+
+  .img-box {
+    width: 50%;
+    img {
+      width: 100%;
+      border-radius: 24px;
+      object-fit: cover;
+    }
+  }
+
+  .text-box {
+    position: relative;
+    width: 50%;
+    color: white;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    h2 {
+      font-size: clamp(1.5rem, 3vw, 2rem);
+      margin-bottom: 20px;
+    }
+
+    span {
+      display: block;
+      font-size: 0.95rem;
+      line-height: 1.8;
+    }
+
+    .inner-box {
+      width: min(450px, 100%);
+      position: relative;
+    }
+
+    .go-shop {
+      margin: 30px auto 0;
+    }
+  }
+
+  @media (max-width: 1024px) {
+    gap: 40px;
+    .text-box {
+      text-align: left;
+      justify-content: flex-start;
+    }
+  }
+
+  @media (max-width: 900px) {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .img-box,
+    .text-box {
+      width: 100%;
+    }
+
+    .text-box {
+      text-align: left;
+      align-items: flex-start;
+      .inner-box {
+        position: static;
+        transform: none;
+        margin: 0;
+      }
+    }
+  }
+
+  @media (max-width: 600px) {
+    gap: 32px;
+    .text-box {
+      span {
+        font-size: 0.9rem;
+      }
+    }
+  }
+`;
+
 export const Content2Style = styled.section`
-box-sizing: border-box;
-padding: 150px;
-.Con-Text{width: 900px; margin:auto; text-align:center}
-color: #E3F2FD;
-`
+  box-sizing: border-box;
+  padding: 150px 0;
+  color: #e3f2fd;
+
+  .Con-Text {
+    width: min(900px, 100%);
+    margin: auto;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    span {
+      font-size: 1rem;
+    }
+  }
+
+  @media (max-width: 768px) {
+    padding: 100px 0;
+    .Con-Text {
+      span {
+        font-size: 0.95rem;
+      }
+    }
+  }
+
+  @media (max-width: 480px) {
+    padding: 72px 0;
+  }
+`;
 
 export const BannerStyle = styled.div`
-margin-bottom: 100px;
-`
+  margin-bottom: 100px;
+
+  @media (max-width: 768px) {
+    margin-bottom: 60px;
+  }
+`;
 
 export const Content4Style = styled.section`
-margin-top: 100px;
-display: flex;
-justify-content: space-evenly;
-color: #E3F2FD;
-p{line-height:25px; font-size:15px;}
-.title {margin-bottom:30px}
-margin-bottom: 100px;
-`
+  margin-top: 100px;
+  margin-bottom: 100px;
+  display: flex;
+  justify-content: space-evenly;
+  gap: 40px;
+  color: #e3f2fd;
+
+  p {
+    line-height: 25px;
+    font-size: 0.95rem;
+  }
+
+  .title {
+    margin-bottom: 30px;
+    font-weight: 600;
+  }
+
+  > div {
+    max-width: 320px;
+  }
+
+  @media (max-width: 1024px) {
+    gap: 24px;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 32px;
+    > div {
+      max-width: none;
+      background: rgba(13, 27, 61, 0.35);
+      padding: 24px;
+      border-radius: 16px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    margin-top: 72px;
+    margin-bottom: 72px;
+    p {
+      font-size: 0.9rem;
+    }
+  }
+`;

--- a/src/pages/main/MainStyle.js
+++ b/src/pages/main/MainStyle.js
@@ -1,25 +1,126 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
 export const VisualWrap = styled.section`
-    width:100%; position:relative;
-    margin-top: 100px;
-    .video-box{position:relative;
-      video{width:100%; border-radius:30px;}
-    }
-    .buy-now{width: 150px; height: 50px; background:#000035; border-radius:10px; text-align:center; padding:15px; box-sizing:border-box;
-      position: absolute; right: 100px; bottom:40px;
-      a {color:#E3F2FD; width: 100%; height:100%; display:block}
-    }
-    
-.Main-Text {position:absolute; left: 50%;top: -16%; transform:translateX(-50%); a {color:#E3F2FD}}
+  width: 100%;
+  position: relative;
+  margin-top: 100px;
 
-`
+  .video-box {
+    position: relative;
+    border-radius: 30px;
+    overflow: hidden;
+
+    video {
+      width: 100%;
+      display: block;
+    }
+  }
+
+  .buy-now {
+    width: 150px;
+    height: 50px;
+    background: #000035;
+    border-radius: 10px;
+    text-align: center;
+    padding: 15px;
+    position: absolute;
+    right: 100px;
+    bottom: 40px;
+
+    a {
+      color: #e3f2fd;
+      width: 100%;
+      height: 100%;
+      display: block;
+      font-weight: 600;
+    }
+  }
+
+  .Main-Text {
+    position: absolute;
+    left: 50%;
+    top: -16%;
+    transform: translateX(-50%);
+    text-align: center;
+    a {
+      color: #e3f2fd;
+      font-weight: 600;
+    }
+  }
+
+  @media (max-width: 1024px) {
+    margin-top: 80px;
+    .buy-now {
+      right: 40px;
+      bottom: 32px;
+    }
+  }
+
+  @media (max-width: 768px) {
+    margin-top: 60px;
+    .buy-now {
+      position: static;
+      margin: 16px auto 0;
+    }
+    .Main-Text {
+      position: static;
+      transform: none;
+      margin: 24px auto 0;
+    }
+  }
+`;
 
 export const MainWrap = styled.div`
-    &.main{}
-    h2 { font-size:30px; font-weight:700 }
-    .swiperStyle{
-      margin-top: 100px;
-      img{height:700px; width:100%}
+  padding: 80px 0 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 120px;
+
+  h2 {
+    font-size: 30px;
+    font-weight: 700;
+  }
+
+  .swiperStyle {
+    margin-top: 100px;
+
+    img {
+      width: 100%;
+      height: 700px;
+      object-fit: cover;
+      border-radius: 24px;
     }
-`
+  }
+
+  @media (max-width: 1024px) {
+    gap: 90px;
+    .swiperStyle {
+      margin-top: 60px;
+      img {
+        height: 520px;
+      }
+    }
+  }
+
+  @media (max-width: 768px) {
+    padding: 60px 0 80px;
+    gap: 72px;
+
+    .swiperStyle {
+      margin-top: 40px;
+      img {
+        height: 360px;
+      }
+    }
+  }
+
+  @media (max-width: 480px) {
+    gap: 56px;
+
+    .swiperStyle {
+      img {
+        height: 260px;
+      }
+    }
+  }
+`;

--- a/src/pages/notice/Notice.jsx
+++ b/src/pages/notice/Notice.jsx
@@ -1,5 +1,5 @@
 import NoticeList from "../../components/notice/NoticeList";
-import Pagination from "../../components/pagination/pagination";
+import Pagination from "../../components/pagination/Pagination";
 import { NoticeWrap } from "./NoticeStyle";
 
 

--- a/src/pages/product/ProductStyle.js
+++ b/src/pages/product/ProductStyle.js
@@ -1,24 +1,115 @@
-import styled from 'styled-components'
+import styled from "styled-components";
 
-export const ProductWrap = styled.div` 
-    .inner { padding:100px 0 }
-    h2 {  margin-bottom:50px; font-weight:700; color:#E3F2FD}
+export const ProductWrap = styled.div`
+  .inner {
+    padding: 100px 0;
+  }
 
-    .cart-box { display: flex;flex-wrap: wrap;;
-        article {width: 23%;padding: 20px; box-sizing: border-box; margin-bottom: 30px; text-align: center; border-radius : 20px; margin-right:24px; border:2px solid #E0E0E0;
-            .product-img{background:#E3F2FD}
-            div {margin-bottom: 25px;}
-            img { width: 100%; height:130px}
-            h3 {font-size: 12px; margin-bottom: 10px; color:#80CBC4;}
-            h4 {font-size: 18px; line-height: 1.3; font-weight: 300;margin-bottom: 20px;}
-            p { font-weight:400; color:#64FFDA;display: flex; justify-content: space-between; align-items: center; margin-top: 10px;
-                button {padding: 8px 30px; vertical-align: middle; color:#E3F2FD; font-size: 12px; background-color:#000035; border: 1px solid #E3F2FD;
-                &.off { background: #E3F2FD; padding: 8px 26px; vertical-align: middle; color:#558B2F;}
-                }
-                span { font-size: 14px; }
-            }
+  h2 {
+    margin-bottom: 50px;
+    font-weight: 700;
+    color: #e3f2fd;
+  }
+
+  .cart-box {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 28px;
+
+    article {
+      padding: 24px;
+      box-sizing: border-box;
+      text-align: center;
+      border-radius: 20px;
+      border: 2px solid rgba(227, 242, 253, 0.2);
+      background: rgba(13, 27, 61, 0.35);
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+
+      .product-img {
+        background: #e3f2fd;
+        border-radius: 16px;
+        padding: 16px;
+      }
+
+      img {
+        width: 100%;
+        height: 130px;
+        object-fit: contain;
+      }
+
+      h3 {
+        font-size: 0.85rem;
+        margin-bottom: 10px;
+        color: #80cbc4;
+      }
+
+      h4 {
+        font-size: 1.1rem;
+        line-height: 1.3;
+        font-weight: 300;
+      }
+
+      p {
+        font-weight: 400;
+        color: #64ffda;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-top: auto;
+        gap: 12px;
+
+        button {
+          padding: 10px 22px;
+          border-radius: 999px;
+          background-color: #000035;
+          border: 1px solid #e3f2fd;
+          color: #e3f2fd;
+          font-size: 0.85rem;
+          transition: background 0.3s ease, color 0.3s ease;
+
+          &:hover {
+            background: #0d1b3d;
+          }
+
+          &.off {
+            background: #e3f2fd;
+            color: #1b5e20;
+            border-color: transparent;
+          }
         }
+
+        span {
+          font-size: 0.95rem;
+        }
+      }
+    }
+  }
+
+  @media (max-width: 1024px) {
+    .inner {
+      padding: 80px 0;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .inner {
+      padding: 60px 0;
     }
 
+    .cart-box {
+      gap: 20px;
 
-`
+      article {
+        padding: 20px;
+      }
+    }
+  }
+
+  @media (max-width: 480px) {
+    .cart-box {
+      grid-template-columns: 1fr;
+    }
+  }
+`;

--- a/src/store/modules/authSlice.jsx
+++ b/src/store/modules/authSlice.jsx
@@ -1,37 +1,53 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialUsers = [
+  { id: 0, email: "hello@naver.com", password: "hi1234", username: "두두" },
+];
 
 const initialState = {
- user : null,
- authed: false,
- dataList:[{id:0, email:'hello@naver.com',password:'hi1234',username:'두두'}]
-}
-let no = 0;
+  user: null,
+  authed: false,
+  dataList: initialUsers,
+};
+
+let nextId = initialUsers.reduce((max, user) => Math.max(max, user.id), -1) + 1;
+
 export const authSlice = createSlice({
-  name: 'auth',
+  name: "auth",
   initialState,
   reducers: {
-    login: (state,action) => {
-        const {email, password} = action.payload
-        const findEmail = state.dataList.find(item => item.email === email)
-        const findpassword = state.dataList.find(item => item.password === password)
-        if(findpassword === undefined || findEmail === undefined) {alert('일치하는 정보가 없습니다')}
-        if( findEmail.password === password) {
-          state.user = findEmail
-          state.authed = true
-        }
+    login: (state, action) => {
+      const email = action.payload.email?.trim().toLowerCase();
+      const password = action.payload.password?.trim();
+      const matchedUser = state.dataList.find((item) => item.email === email);
+
+      if (!matchedUser || matchedUser.password !== password) {
+        alert("일치하는 정보가 없습니다");
+        state.user = null;
+        state.authed = false;
+        return;
+      }
+
+      state.user = matchedUser;
+      state.authed = true;
     },
-    logout:(state,action) =>{
-        state.user = null
-        state.authed = false
+    logout: (state) => {
+      state.user = null;
+      state.authed = false;
     },
-    singup:(state,action) => {
-      const {email, tel , username ,password} = action.payload
-      state.dataList = [...state.dataList, {id:no++,...action.payload}]
-    }
+    signup: (state, action) => {
+      state.dataList = [
+        ...state.dataList,
+        {
+          id: nextId++,
+          ...action.payload,
+        },
+      ];
+    },
   },
-})
+});
 
 // Action creators are generated for each case reducer function
-export const { login, logout, singup} = authSlice.actions
+export const { login, logout, signup } = authSlice.actions;
 
-export default authSlice.reducer
+export default authSlice.reducer;

--- a/src/styled/GlobalStyle.js
+++ b/src/styled/GlobalStyle.js
@@ -1,25 +1,91 @@
-import { createGlobalStyle } from 'styled-components'
-import reset from 'styled-reset'
+import { createGlobalStyle } from "styled-components";
+import reset from "styled-reset";
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
-  
+
+  :root {
+    color-scheme: dark;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
   body {
     font-size: 16px;
-    font-family: 'Noto Sans KR', sans-serif;
+    font-family: "Noto Sans KR", sans-serif;
     background: #000035;
+    color: #e3f2fd;
+    line-height: 1.6;
+    min-height: 100vh;
   }
+
   a {
     text-decoration: none;
-    color:#333; 
+    color: inherit;
   }
-  li { list-style:none;}
-  img { vertical-align: top; }
-  
-  .inner { width:1200px; margin:auto; box-sizing:border-box; position:relative }
-  .main { width: 100%;}
-  .main h2 { text-align: center; font-size: 40px; margin-bottom: 30px; }
-  button { border:none; cursor: pointer; }
-`
+
+  button {
+    border: none;
+    cursor: pointer;
+    font-family: inherit;
+  }
+
+  li {
+    list-style: none;
+  }
+
+  img {
+    vertical-align: top;
+    max-width: 100%;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+
+  .inner {
+    width: min(1200px, 100%);
+    margin: 0 auto;
+    padding: 0 24px;
+    position: relative;
+  }
+
+  .main {
+    width: 100%;
+  }
+
+  .main h2 {
+    text-align: center;
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    margin-bottom: 30px;
+  }
+
+  @media (max-width: 768px) {
+    body {
+      font-size: 15px;
+    }
+
+    .inner {
+      padding: 0 16px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    body {
+      font-size: 14px;
+    }
+  }
+`;
 
 export default GlobalStyle;


### PR DESCRIPTION
## Summary
- wire the join and login pages into the redux auth slice, prevent duplicate accounts, and add clearer onboarding messaging
- replace the header navigation with an auth-aware cart badge and mobile toggle
- refresh global, product, cart, notice, customer, and about styling to support responsive layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0f85af28883289d2ad413ba33b4fe